### PR TITLE
Use 127.0.0.1 for ingress host

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ OpenTelemetry is used for traces and metrics.
 
 The Keptn Lifecycle Toolkit is used for validating the delivery of new artifacts.
 
-### Setup a Kind Cluster with nginx ingress controller
+## Setup a Kind Cluster with nginx ingress controller
 
 Create Kind Cluster which exposes Port 80 and 443
 

--- a/README.md
+++ b/README.md
@@ -35,15 +35,10 @@ kubectl wait --namespace ingress-nginx \
   --timeout=90s
 ```
 
-Update `ingress.yaml` with your IP address and apply it
+Apply `ingress.yaml` to expose the application via [http://127.0.0.1.nip.io](http://127.0.0.1.nip.io)
 
 ```shell
-IP_ADDRESS=$(hostname -I | awk '{print $1}')
-sed -i "s/YOUR_IP_ADDRESS/$IP_ADDRESS/g" ingress.yaml
-
 kubectl apply -f manifests/ingress.yaml
-
-echo "Your ingress is available using http://$IP_ADDRESS.nip.io"
 ```
 
 

--- a/manifests/ingress.yaml
+++ b/manifests/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-  - host: YOUR_IP_ADDRESS.nip.io
+  - host: 127.0.0.1.nip.io
     http:
       paths:
       - path: /


### PR DESCRIPTION
As this demo should run locally, it is not needed to expose the ingress on the LAN IP Address.