### PR TITLE
Use gRPC exporter and add OTel environment variables

### DIFF
--- a/demoapp/app.js
+++ b/demoapp/app.js
@@ -5,23 +5,14 @@
 /*instrumentation.js*/
 const opentelemetry = require("@opentelemetry/sdk-node");
 const {getNodeAutoInstrumentations,} = require("@opentelemetry/auto-instrumentations-node");
-const {OTLPTraceExporter} = require("@opentelemetry/exporter-trace-otlp-proto");
-const {OTLPMetricExporter} = require("@opentelemetry/exporter-metrics-otlp-proto");
+const {OTLPTraceExporter} = require("@opentelemetry/exporter-trace-otlp-grpc");
+const {OTLPMetricExporter} = require("@opentelemetry/exporter-metrics-otlp-grpc");
 const {PeriodicExportingMetricReader} = require('@opentelemetry/sdk-metrics');
 
 const sdk = new opentelemetry.NodeSDK({
-  traceExporter: new OTLPTraceExporter({
-    // optional - default url is http://localhost:4318/v1/traces
-    url: "http://localhost:4318/v1/traces",
-    // optional - collection of custom headers to be sent with each request, empty by default
-    headers: {},
-  }),
+  traceExporter: new OTLPTraceExporter({}),
   metricReader: new PeriodicExportingMetricReader({
-    exporter: new OTLPMetricExporter({
-      url: '<your-otlp-endpoint>/v1/metrics', // url is optional and can be omitted - default is http://localhost:4318/v1/metrics
-      headers: {}, // an optional object containing custom headers to be sent with each request
-      concurrencyLimit: 1, // an optional limit on pending requests
-    }),
+    exporter: new OTLPMetricExporter({}),
   }),
   instrumentations: [getNodeAutoInstrumentations()],
 });

--- a/demoapp/package-lock.json
+++ b/demoapp/package-lock.json
@@ -13,8 +13,8 @@
         "@openfeature/js-sdk": "^1.3.1",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/auto-instrumentations-node": "^0.37.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.41.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.41.0",
         "@opentelemetry/sdk-metrics": "^1.15.0",
         "@opentelemetry/sdk-node": "^0.41.0",
         "express": "^4.18.2"
@@ -615,13 +615,15 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
       "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.0.tgz",
-      "integrity": "sha512-YttGW1XEHB9GocXtEY+n0qAT2Ewi/P4l7882kYK4kEl78EAnVvvWvFX1El+TvHA3D2LHDxx9ASu1i+icCqj/Fw==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.41.0.tgz",
+      "integrity": "sha512-IVLf07OTFmPs6SwViYNBGPTnOGN2gDLhQiw/O60m7CBvBOfEfcg83w/bVF4Va3m6H5cReVbQsKEx+AaCVl6smg==",
       "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
         "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/otlp-exporter-base": "0.41.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.41.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.41.0",
         "@opentelemetry/otlp-transformer": "0.41.0",
         "@opentelemetry/resources": "1.15.0",
         "@opentelemetry/sdk-metrics": "1.15.0",
@@ -634,15 +636,13 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.41.0.tgz",
-      "integrity": "sha512-6cQlyV/cQk/kzyI/u/eoAOjtQO+SkWUJbnyI1nWGYADwtbJtJ4sl6ks7t7cdppTr7/66fMgXVKIIjjPowoEcGw==",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.0.tgz",
+      "integrity": "sha512-YttGW1XEHB9GocXtEY+n0qAT2Ewi/P4l7882kYK4kEl78EAnVvvWvFX1El+TvHA3D2LHDxx9ASu1i+icCqj/Fw==",
       "dependencies": {
         "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.41.0",
         "@opentelemetry/otlp-exporter-base": "0.41.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.41.0",
         "@opentelemetry/otlp-transformer": "0.41.0",
         "@opentelemetry/resources": "1.15.0",
         "@opentelemetry/sdk-metrics": "1.15.0",

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -13,8 +13,8 @@
     "@openfeature/js-sdk": "^1.3.1",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/auto-instrumentations-node": "^0.37.1",
-    "@opentelemetry/exporter-metrics-otlp-proto": "^0.41.0",
-    "@opentelemetry/exporter-trace-otlp-proto": "^0.41.0",
+    "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.0",
+    "@opentelemetry/exporter-trace-otlp-grpc": "^0.41.0",
     "@opentelemetry/sdk-metrics": "^1.15.0",
     "@opentelemetry/sdk-node": "^0.41.0",
     "express": "^4.18.2"

--- a/manifests/app/deployment.yaml
+++ b/manifests/app/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         - name: FLAGD_PORT
           value: "8030"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: "otel-collector.keptn-lifecycle-toolkit-system:4317"
-        # Uncomment the below to troubleshoot exporter->collector connection issues
+          value: "http://otel-collector.keptn-lifecycle-toolkit-system:4317"
+        # Uncomment the below for troubleshooting OTel
         #- name: OTEL_LOG_LEVEL
         #  value: "info"
         livenessProbe:

--- a/manifests/app/deployment.yaml
+++ b/manifests/app/deployment.yaml
@@ -31,6 +31,11 @@ spec:
         env:
         - name: FLAGD_PORT
           value: "8030"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "otel-collector.keptn-lifecycle-toolkit-system:4317"
+        # Uncomment the below to troubleshoot exporter->collector connection issues
+        #- name: OTEL_LOG_LEVEL
+        #  value: "info"
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This PR 
- makes the example use the gRPC exporter to be compatible with the existing collector config
- adds OTel exporter environment variable to the manifest that will be automatically picked up by the exporter 