### PR TITLE
docs: add links to DORA dashboards & Jaeger

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -91,3 +91,5 @@ Expect to see the text `Hello World!`.
 ## Observability Tooling
 - Grafana is available: `http://grafana.127.0.0.1.nip.io` (username: `admin`, password: `admin`)
 - Prometheus is available: `http://prometheus.127.0.0.1.nip.io`
+- Jaeger is available: `http://jaeger.127.0.0.1.nip.io`
+- DORA Metrics dashboard is available: `http://grafana.127.0.0.1.nip.io/d/nbiPNgN4z/keptn-applications`


### PR DESCRIPTION
This PR:

- Adds readme links to Jaeger and DORA dashboard