### PR TITLE
Add servicemonitor for klt metrics server

### DIFF
--- a/gitops/manifests/klt-config/servicemonitor.yaml
+++ b/gitops/manifests/klt-config/servicemonitor.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    serviceapp: klt-metrics-server
+  name: klt-metrics-server
+  namespace: keptn-lifecycle-toolkit-system
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      port: metrics
+  namespaceSelector:
+    matchNames:
+      - keptn-lifecycle-toolkit-system
+  selector:
+    matchLabels:
+      control-plane: metrics-operator


### PR DESCRIPTION
Add service monitor for klt metrics server. This could be used to configure alerting rules in grafana if needed