### PR TITLE
Update featureflags.yaml

### DIFF
--- a/gitops/manifests/featureflags/featureflags.yaml
+++ b/gitops/manifests/featureflags/featureflags.yaml
@@ -16,7 +16,7 @@ spec:
       slowFlag:
         state: "ENABLED"
         variants:
-          "on": "true"
-          "off": "false"
-        defaultVariant: "off"
+          "true": true
+          "false": false
+        defaultVariant: "false"
         targeting: {}


### PR DESCRIPTION
Fix slow Flag to resolve TypeMismatchError: FlagdError:, TYPE_MISMATCH
    at GRPCService.onRejected (/usr/src/app/node_modules/@openfeature/flagd-provider/index.cjs:1426:27)
    at /usr/src/app/node_modules/@protobuf-ts/runtime-rpc/build/commonjs/unary-call.js:32:151
    at processTicksAndRejections (node:internal/process/task_queues:96:5)