### PR TITLE
install app of apps first

### DIFF
--- a/gitops/README.md
+++ b/gitops/README.md
@@ -40,11 +40,20 @@ kubectl -n argocd apply -f gitops/app-of-apps.yaml
 
 The App of Apps will create all other apps which are included in the `applications` folder from within GitHub Repository.
 
-## Get ArgoCD Password and Port-Forward ArgoCD UI
+## Get ArgoCD Password
+
+```
+argocd admin initial-password -n argocd
+```
+
+## Access ArgoCD
+
+It may take a few moments, but Argo will be available at: http://argocd.127.0.0.1.nip.io
+
+You can also port forward to access:
 
 ```
 kubectl port-forward svc/argocd-server -n argocd 8080:443
-argocd admin initial-password -n argocd
 ```
 
 # App of Apps and Sync Waves Explained

--- a/gitops/README.md
+++ b/gitops/README.md
@@ -32,13 +32,6 @@ Wait for all deployments to be ready. This is important because otherwise the in
 kubectl wait --for=condition=Available=True deploy -n argocd --all --timeout=90s
 ```
 
-## Get ArgoCD Password and Port-Forward ArgoCD UI
-
-```
-kubectl port-forward svc/argocd-server -n argocd 8080:443
-argocd admin initial-password -n argocd
-```
-
 ## Apply the "App of Apps"
 
 ```
@@ -46,6 +39,15 @@ kubectl -n argocd apply -f gitops/app-of-apps.yaml
 ```
 
 The App of Apps will create all other apps which are included in the `applications` folder from within GitHub Repository.
+
+## Get ArgoCD Password and Port-Forward ArgoCD UI
+
+```
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+argocd admin initial-password -n argocd
+```
+
+# App of Apps and Sync Waves Explained
 
 Sync waves allow you to ensure that certain resources are healthy before others are rolled out. In short, it's a way of saying "install A before B".
 


### PR DESCRIPTION
This PR:

- Switches the commands around so that app of apps starts installing immediately before login

This is a small change but once users log in, they will see "something happening" and it gives a little bit of extra time for installs to occur.