### PR TITLE
Reduce scraping time for collector and display deltas

### DIFF
--- a/gitops/manifests/otel-collector/deploy.yaml
+++ b/gitops/manifests/otel-collector/deploy.yaml
@@ -144,7 +144,7 @@ metadata:
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      interval: 30s
+      interval: 5s
       port: metrics
   namespaceSelector:
     matchNames:

--- a/gitops/manifests/prometheus-grafana/grafana-dashboard-openfeature.yaml
+++ b/gitops/manifests/prometheus-grafana/grafana-dashboard-openfeature.yaml
@@ -211,7 +211,7 @@ data:
                 "uid": "P1809F7CD0C75ACF3"
               },
               "editorMode": "code",
-              "expr": "sum(feature_flag_evaluation_success_total) by ( key, variant )",
+              "expr": "sum(delta(feature_flag_evaluation_success_total[1m])) by ( key, variant )",
               "format": "time_series",
               "hide": false,
               "legendFormat": "__auto",


### PR DESCRIPTION
This PR reduces the scraping of metric from the collector to 5s and uses delta for displaying FF evaluation split by key and variant

Example of the new dashboard:
![image](https://github.com/AloisReitbauer/progressiveDelivery-masterclass/assets/992621/3d737f64-aa3e-4184-b76b-038a1722aad4)
