### PR TITLE
update hook, absorb semconv changes

### DIFF
--- a/demoapp/package-lock.json
+++ b/demoapp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@openfeature/flagd-provider": "^0.7.6",
         "@openfeature/js-sdk": "^1.3.3",
-        "@openfeature/open-telemetry-hooks": "^0.2.1",
+        "@openfeature/open-telemetry-hooks": "^0.2.2",
         "@opentelemetry/api": "^1.4.1",
         "@opentelemetry/auto-instrumentations-node": "^0.37.1",
         "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.0",
@@ -160,9 +160,9 @@
       }
     },
     "node_modules/@openfeature/open-telemetry-hooks": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@openfeature/open-telemetry-hooks/-/open-telemetry-hooks-0.2.1.tgz",
-      "integrity": "sha512-7bSfuI8QsCA+qldMePSBfJr+hyw7d870nm3eeXZwllDxor8kGIsDyl036fFrSKyTGaLtvJ9MFLwE2qtd2wG+HA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@openfeature/open-telemetry-hooks/-/open-telemetry-hooks-0.2.2.tgz",
+      "integrity": "sha512-64Yc9TAs/ge6fqE1zvU2R0IEhDZ2iF8d5mYaWvWKpSaINUoBa9OdLBxDmJ9DXmKQ/ybMs4QJCF8DQ3acddEAiQ==",
       "peerDependencies": {
         "@openfeature/js-sdk": "^1.0.0",
         "@opentelemetry/api": ">=1.3.0"

--- a/demoapp/package.json
+++ b/demoapp/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@openfeature/flagd-provider": "^0.7.6",
     "@openfeature/js-sdk": "^1.3.3",
-    "@openfeature/open-telemetry-hooks": "^0.2.1",
+    "@openfeature/open-telemetry-hooks": "^0.2.2",
     "@opentelemetry/api": "^1.4.1",
     "@opentelemetry/auto-instrumentations-node": "^0.37.1",
     "@opentelemetry/exporter-metrics-otlp-grpc": "^0.41.0",

--- a/gitops/manifests/prometheus-grafana/grafana-dashboard-openfeature.yaml
+++ b/gitops/manifests/prometheus-grafana/grafana-dashboard-openfeature.yaml
@@ -222,7 +222,7 @@ data:
                 "uid": "P1809F7CD0C75ACF3"
               },
               "editorMode": "code",
-              "expr": "sum(delta(feature_flag_evaluation_success_total[1m])) by ( key, variant )",
+              "expr": "sum(delta(feature_flag_evaluation_success_total[1m])) by ( feature_flag_key, feature_flag_variant )",
               "format": "time_series",
               "hide": false,
               "legendFormat": "__auto",


### PR DESCRIPTION
The semantic conventions for the Metrics hook weren't quite correct. This has been fixed. This change pulls in the fix and changes a query accordingly.